### PR TITLE
Specify Python version for Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Questo progetto contiene un semplice bot Telegram basato su [aiogram](https://gi
 
 ## Deploy su Render
 1. Crea un nuovo servizio di tipo **Web Service** su [Render](https://dashboard.render.com/). Seleziona questo repository GitHub e usa il file `render.yaml` incluso.
+   Questo file imposta `pythonVersion: 3.11`, perciò assicurati di usare la stessa
+   versione anche in locale in modo da avere un ambiente coerente.
 2. Durante la configurazione, aggiungi le variabili d'ambiente nella sezione **Environment**:
    - `TELEGRAM_BOT_TOKEN`: il token del bot Telegram
    - `OPENAI_API_KEY`: la tua chiave API OpenAI

--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ services:
     region: oregon
     plan: free
     branch: main
+    pythonVersion: 3.11
     buildCommand: "pip install -r requirements.txt"
     startCommand: "python main.py"
     envVars:


### PR DESCRIPTION
## Summary
- pin Python 3.11 in `render.yaml`
- document Python version requirement for Render in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685efe82a65c832090cd879c31ecdcc9